### PR TITLE
spike: add an option to download the Zorb

### DIFF
--- a/packages/zorb-web-site/pages/nft/[id].tsx
+++ b/packages/zorb-web-site/pages/nft/[id].tsx
@@ -109,6 +109,13 @@ export default function Zorb({ id, tokenInfo }: any) {
                 View on ZORA <ArrowNext />
               </a>
             </div>
+            <div>
+              <a
+                download={`zorb-${id}.svg`}
+                href={image}
+                title={`Zorb #${id}`}
+              >💾 Download SVG</a>
+            </div>
           </div>
         </RoundedContainer>
       </div>


### PR DESCRIPTION
## Summary

This is a spike to add an option to download the Zorb as an SVG.

🎥 Motion picture: 
![zorb-download-spike](https://user-images.githubusercontent.com/78528185/147999727-eb17bff2-ff4f-44b3-a05f-038f1813c461.gif)
